### PR TITLE
[FIX] cooperator_website: Use name field instead of non-existent datas_fname

### DIFF
--- a/cooperator_website/controllers/main.py
+++ b/cooperator_website/controllers/main.py
@@ -458,11 +458,9 @@ class WebsiteSubscription(http.Controller):
             for field_value in post_file:
                 attachment_value = {
                     "name": field_value.filename,
-                    "res_name": field_value.filename,
                     "res_model": "subscription.request",
                     "res_id": subscription_id,
                     "datas": base64.encodestring(field_value.read()),
-                    "datas_fname": field_value.filename,
                 }
                 attach_obj.sudo().create(attachment_value)
 


### PR DESCRIPTION
Internal task: https://gestion.coopiteasy.be/web#id=9491&action=475&active_id=408&model=project.task&view_type=form&menu_id=536

Simple fix that was overlooked during migration.

Signed-off-by: Carmen Bianca BAKKER <carmen@coopiteasy.be>