### PR TITLE
[14.0][FIX] fix random required fields on website form

### DIFF
--- a/cooperator/models/subscription_request.py
+++ b/cooperator/models/subscription_request.py
@@ -39,7 +39,7 @@ class SubscriptionRequest(models.Model):
     _inherit = ["mail.thread", "mail.activity.mixin"]
 
     def get_required_field(self):
-        required_fields = _REQUIRED
+        required_fields = _REQUIRED.copy()
         company = self.env.company
         if company.data_policy_approval_required:
             required_fields.append("data_policy_approved")


### PR DESCRIPTION
ensure `_REQUIRED` is not modified, otherwise it is a global variable, and it causes these problems:

* in a multi-database setup, the required fields can include additional fields because of the configuration of other databases.
* values are added to the list continuously, which causes a memory leak.

this is the 14.0 version of #52.