### PR TITLE
[12.0][FIX] cooperator: remove selection widget

### DIFF
--- a/cooperator/readme/newsfragments/54.feature.rst
+++ b/cooperator/readme/newsfragments/54.feature.rst
@@ -1,0 +1,2 @@
+Removed all selection widgets.
+

--- a/cooperator/views/operation_request_view.xml
+++ b/cooperator/views/operation_request_view.xml
@@ -103,13 +103,13 @@
                             <field
                                 name="share_product_id"
                                 attrs="{'readonly':[('state','!=','draft')]}"
-                                widget="selection"
+                                options="{'no_create':True}"
                             />
                             <field name="share_short_name" readonly="True" />
                             <field
                                 name="share_to_product_id"
                                 attrs="{'invisible':[('operation_type','!=','convert')],'required':[('operation_type','=','convert')],'readonly':[('state','!=','draft')]}"
-                                widget="selection"
+                                options="{'no_create':True}"
                             />
                             <field name="share_to_short_name" readonly="True" />
                             <field

--- a/cooperator/views/subscription_request_view.xml
+++ b/cooperator/views/subscription_request_view.xml
@@ -152,7 +152,7 @@
                             <field name="date" />
                             <field name="source" />
                             <field name="ordered_parts" />
-                            <field name="share_product_id" widget="selection" />
+                            <field name="share_product_id" options="{'no_create':True}"/>
                             <field name="share_short_name" />
                             <field name="share_unit_price" />
                             <field name="subscription_amount" />

--- a/cooperator/wizard/create_subscription_from_partner.xml
+++ b/cooperator/wizard/create_subscription_from_partner.xml
@@ -30,7 +30,7 @@
                         attrs="{'invisible':[('is_company','=',False)],'required':[('is_company','=',True)]}"
                     />
                     <field name="bank_account" />
-                    <field name="share_product" widget="selection" />
+                    <field name="share_product" options="{'no_create':True}" />
                     <field name="share_qty" />
                     <field name="share_unit_price" />
                     <field name="subscription_amount" />


### PR DESCRIPTION
Selection widget limits the values to 128 items and has no search
function.
