### PR TITLE
[14.0][IMP] l10n_es_cooperator: add state control to vat field

### DIFF
--- a/l10n_es_cooperator/models/subscription_request.py
+++ b/l10n_es_cooperator/models/subscription_request.py
@@ -10,6 +10,8 @@ class SubscriptionRequest(models.Model):
         The Tax Identification Number. Complete it if the contact is subjected to
         government taxes. Used in some legal statements."
         """,
+        readonly=True,
+        states={"draft": [("readonly", False)]},
     )
 
     def get_partner_vals(self):


### PR DESCRIPTION
Add state control to the VAT field, as is implemented in `cooperator`

Depends on #57 