### PR TITLE
[14.0][IMP] improve cooperator multi-company data consistency

### DIFF
--- a/cooperator/__init__.py
+++ b/cooperator/__init__.py
@@ -6,8 +6,5 @@ from . import wizard
 
 
 def post_init(cr, registry):
-    # the subscription journal must be created for each company.
     env = api.Environment(cr, SUPERUSER_ID, {})
-    subscription_request_model = env["subscription.request"]
-    for company in env.companies:
-        subscription_request_model.create_journal(company)
+    env.companies._init_cooperator_data()

--- a/cooperator/__init__.py
+++ b/cooperator/__init__.py
@@ -1,10 +1,3 @@
-from odoo import api, SUPERUSER_ID
-
 from . import models
 from . import report
 from . import wizard
-
-
-def post_init(cr, registry):
-    env = api.Environment(cr, SUPERUSER_ID, {})
-    env.companies._init_cooperator_data()

--- a/cooperator/__init__.py
+++ b/cooperator/__init__.py
@@ -1,3 +1,13 @@
+from odoo import api, SUPERUSER_ID
+
 from . import models
 from . import report
 from . import wizard
+
+
+def post_init(cr, registry):
+    # the subscription journal must be created for each company.
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    subscription_request_model = env["subscription.request"]
+    for company in env.companies:
+        subscription_request_model.create_journal(company)

--- a/cooperator/__manifest__.py
+++ b/cooperator/__manifest__.py
@@ -54,5 +54,4 @@
         "demo/users.xml",
     ],
     "application": True,
-    "post_init_hook": "post_init",
 }

--- a/cooperator/__manifest__.py
+++ b/cooperator/__manifest__.py
@@ -54,4 +54,5 @@
         "demo/users.xml",
     ],
     "application": True,
+    "post_init_hook": "post_init",
 }

--- a/cooperator/__manifest__.py
+++ b/cooperator/__manifest__.py
@@ -7,7 +7,7 @@
 {
     "name": "Cooperators",
     "summary": "Manage your cooperators",
-    "version": "14.0.1.6.0",
+    "version": "14.0.1.7.0",
     "depends": [
         "base",
         "web",

--- a/cooperator/data/data.xml
+++ b/cooperator/data/data.xml
@@ -25,5 +25,9 @@
             <field eval="1" name="number_next" />
             <field eval="1" name="number_increment" />
         </record>
+
+        <function model="res.company" name="_init_cooperator_data">
+            <value model="res.company" search="[]" />
+        </function>
     </data>
 </odoo>

--- a/cooperator/data/data.xml
+++ b/cooperator/data/data.xml
@@ -12,12 +12,6 @@
             <field name="name">Company Share</field>
         </record>
 
-        <record id="subscription_journal" model="account.journal">
-            <field name="name">Subscription Journal</field>
-            <field name="code">SUBJ</field>
-            <field name="type">sale</field>
-        </record>
-
         <record id="sequence_subscription" model="ir.sequence">
             <field name="name">Subscription Register</field>
             <field name="code">subscription.register</field>

--- a/cooperator/demo/coop.xml
+++ b/cooperator/demo/coop.xml
@@ -70,8 +70,8 @@
 
     <!--
         this is here only to support the case where a database is initialized
-        without demo data, and demo data is loaded later on (instead of using
-        only the post_init_hook).
+        without demo data, and demo data is loaded later on (because this
+        function is also called indirectly from the main xml data file).
     -->
     <function model="res.company" name="_init_cooperator_demo_data">
         <value model="res.company" search="[]" />

--- a/cooperator/demo/coop.xml
+++ b/cooperator/demo/coop.xml
@@ -68,23 +68,14 @@
         <field name="country_id" ref="base.be" />
     </record>
 
-    <record id="account_cooperator_demo" model="account.account">
-        <field name="code">416101</field>
-        <field name="name">Cooperators</field>
-        <field name="user_type_id" ref="account.data_account_type_receivable" />
-        <field name="reconcile" eval="True" />
-    </record>
-
-    <record id="account_equity_demo" model="account.account">
-        <field name="name">Equity</field>
-        <field name="code">100910</field>
-        <field eval="True" name="reconcile" />
-        <field name="user_type_id" ref="account.data_account_type_equity" />
-    </record>
-
-    <record id="base.main_company" model="res.company">
-        <field name="property_cooperator_account" ref="account_cooperator_demo" />
-    </record>
+    <!--
+        this is here only to support the case where a database is initialized
+        without demo data, and demo data is loaded later on (instead of using
+        only the post_init_hook).
+    -->
+    <function model="res.company" name="_init_cooperator_demo_data">
+        <value model="res.company" search="[]" />
+    </function>
 
     <record id="product_template_share_type_1_demo" model="product.template">
         <field name="name">Part A - Founder</field>

--- a/cooperator/migrations/14.0.1.7.0/post-set_subscription_journal_on_company.py
+++ b/cooperator/migrations/14.0.1.7.0/post-set_subscription_journal_on_company.py
@@ -1,0 +1,54 @@
+# Copyright 2023 Coop IT Easy SC
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    # the subscription journal is now set on the company instead of using the
+    # global cooperator.subscription_journal xml id.
+    cr.execute(
+        """
+        select id, res_id
+        from ir_model_data
+        where
+            module = 'cooperator' and
+            name = 'subscription_journal'
+        """
+    )
+    row = cr.fetchone()
+    xml_id = row[0]
+    journal_id = row[1]
+    cr.execute(
+        """
+        select id
+        from res_company
+        order by id
+        """
+    )
+    company_rows = cr.fetchall()
+    company_ids = [row[0] for row in company_rows]
+    if len(company_ids) > 1:
+        _logger.warning(
+            "Multiple companies found. "
+            "Please set the subscription journal manually for companies with "
+            "ids: {company_ids}".format(company_ids=company_ids[1:])
+        )
+    cr.execute(
+        """
+        update res_company
+        set subscription_journal_id = %s
+        where id = %s
+        """,
+        (journal_id, company_ids[0]),
+    )
+    cr.execute(
+        """
+        delete
+        from ir_model_data
+        where id = %s
+        """,
+        (xml_id,),
+    )

--- a/cooperator/models/__init__.py
+++ b/cooperator/models/__init__.py
@@ -8,3 +8,4 @@ from . import account_move
 from . import company
 from . import account_journal
 from . import mail_template
+from . import account_chart_template

--- a/cooperator/models/account_chart_template.py
+++ b/cooperator/models/account_chart_template.py
@@ -7,6 +7,6 @@ from odoo import models
 class AccountChartTemplate(models.Model):
     _inherit = "account.chart.template"
 
-    def generate_journals(self, acc_template_ref, company, journals_dict=None):
-        super().generate_journals(acc_template_ref, company, journals_dict)
-        self.env["subscription.request"].create_journal(company)
+    def _load(self, sale_tax_rate, purchase_tax_rate, company):
+        super()._load(sale_tax_rate, purchase_tax_rate, company)
+        company._init_cooperator_data()

--- a/cooperator/models/account_chart_template.py
+++ b/cooperator/models/account_chart_template.py
@@ -1,0 +1,12 @@
+# Copyright 2023 Coop IT Easy SC
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class AccountChartTemplate(models.Model):
+    _inherit = "account.chart.template"
+
+    def generate_journals(self, acc_template_ref, company, journals_dict=None):
+        super().generate_journals(acc_template_ref, company, journals_dict)
+        self.env["subscription.request"].create_journal(company)

--- a/cooperator/models/account_move.py
+++ b/cooperator/models/account_move.py
@@ -12,7 +12,9 @@ class AccountMove(models.Model):
     _inherit = "account.move"
 
     subscription_request = fields.Many2one(
-        "subscription.request", string="Subscription request"
+        "subscription.request",
+        string="Subscription request",
+        check_company=True,
     )
     release_capital_request = fields.Boolean(string="Release of capital request")
 
@@ -79,6 +81,7 @@ class AccountMove(models.Model):
             "partner_id": self.partner_id.id,
             "share_unit_price": line.price_unit,
             "effective_date": effective_date,
+            "company_id": self.company_id.id,
         }
 
     def get_subscription_register_vals(self, line, effective_date):
@@ -89,6 +92,7 @@ class AccountMove(models.Model):
             "share_unit_price": line.price_unit,
             "date": effective_date,
             "type": "subscription",
+            "company_id": self.company_id.id,
         }
 
     def get_membership_vals(self):

--- a/cooperator/models/account_move.py
+++ b/cooperator/models/account_move.py
@@ -68,10 +68,17 @@ class AccountMove(models.Model):
                 user_values = {
                     "partner_id": partner.id,
                     "login": email,
-                    "company_id": self.company_id.id,
-                    "company_ids": company_ids,
                 }
                 user = user_obj.sudo()._signup_create_user(user_values)
+                # passing these values in _signup_create_user() does not work
+                # if the website module is loaded, because it overrides the
+                # method and overwrites them.
+                user.sudo().write(
+                    {
+                        "company_id": self.company_id.id,
+                        "company_ids": company_ids,
+                    }
+                )
                 user.sudo().with_context({"create_user": True}).action_reset_password()
 
         return user

--- a/cooperator/models/account_move.py
+++ b/cooperator/models/account_move.py
@@ -52,8 +52,10 @@ class AccountMove(models.Model):
         user = user_obj.search([("login", "=", email)])
         if user:
             if self.company_id not in user.company_ids:
+                # add the company to the user's companies
                 user.company_ids = [(4, self.company_id.id, 0)]
         else:
+            # set the company as the only company of the user
             company_ids = [(6, 0, [self.company_id.id])]
             user = user_obj.search([("login", "=", email), ("active", "=", False)])
             if user:

--- a/cooperator/models/account_move.py
+++ b/cooperator/models/account_move.py
@@ -10,6 +10,7 @@ from odoo import fields, models
 
 class AccountMove(models.Model):
     _inherit = "account.move"
+    _check_company_auto = True
 
     subscription_request = fields.Many2one(
         "subscription.request",

--- a/cooperator/models/company.py
+++ b/cooperator/models/company.py
@@ -44,6 +44,11 @@ class ResCompany(models.Model):
         " receivable account for the"
         " cooperators",
     )
+    subscription_journal_id = fields.Many2one(
+        "account.journal",
+        "Subscription Journal",
+        readonly=True,
+    )
     unmix_share_type = fields.Boolean(
         string="Unmix share type",
         default=True,

--- a/cooperator/models/company.py
+++ b/cooperator/models/company.py
@@ -157,14 +157,14 @@ class ResCompany(models.Model):
         # possible cases:
         # 1. when a new company is created. in this case it will be called
         #    when the account chart template is loaded.
-        # 2. when a database is initialized with only the cooperator module,
-        #    and the l10n_generic_coa module is loaded after it by the
-        #    post_init_hook of the account module. in this case it is first
-        #    called by the post_init_hook of this module (cooperator) (but
-        #    with no effect, as explained below) and then again when the
-        #    account chart template is loaded.
+        # 2. when a database is initialized with the cooperator module but no
+        #    l10n module, and the l10n_generic_coa module is loaded after the
+        #    cooperator module by the post_init_hook of the account module. in
+        #    this case it is first called by the xml data of this module
+        #    (cooperator) (but with no effect, as explained below) and then
+        #    again when the account chart template is loaded.
         # 3. when the cooperator module is installed on an existing database.
-        #    in this case it is called by the post_init_hook of this module.
+        #    in this case it is called by the xml data of this module.
         subscription_request_model = self.env["subscription.request"]
         for company in self:
             if not company._accounting_data_initialized():

--- a/cooperator/models/company.py
+++ b/cooperator/models/company.py
@@ -143,3 +143,59 @@ class ResCompany(models.Model):
     def onchange_generic_rules_approval_required(self):
         if self.generic_rules_approval_required:
             self.display_generic_rules_approval = True
+
+    def _accounting_data_initialized(self):
+        return self.chart_template_id or self.env[
+            "account.chart.template"
+        ].existing_accounting(self)
+
+    def _init_cooperator_data(self):
+        """
+        Generate default cooperator data for the company.
+        """
+        # this method exists to initialize data correctly for the following
+        # possible cases:
+        # 1. when a new company is created. in this case it will be called
+        #    when the account chart template is loaded.
+        # 2. when a database is initialized with only the cooperator module,
+        #    and the l10n_generic_coa module is loaded after it by the
+        #    post_init_hook of the account module. in this case it is first
+        #    called by the post_init_hook of this module (cooperator) (but
+        #    with no effect, as explained below) and then again when the
+        #    account chart template is loaded.
+        # 3. when the cooperator module is installed on an existing database.
+        #    in this case it is called by the post_init_hook of this module.
+        subscription_request_model = self.env["subscription.request"]
+        for company in self:
+            if not company._accounting_data_initialized():
+                # if no account chart template has been loaded yet and no
+                # accounting data exists, then no accounting data should be
+                # created yet because all existing journals and accounts will
+                # be deleted when the account chart template will be loaded.
+                # this method will be called again after the account chart
+                # template has been loaded.
+                continue
+            subscription_request_model.create_journal(company)
+        # this is called here to support the first 2 cases explained above.
+        self._init_cooperator_demo_data()
+
+    def _init_cooperator_demo_data(self):
+        if not self.env["ir.module.module"].search([("name", "=", "cooperator")]).demo:
+            # demo data must not be loaded, nothing to do
+            return
+        account_account_model = self.env["account.account"]
+        receivable_account_type = self.env.ref("account.data_account_type_receivable")
+        for company in self:
+            if not company._accounting_data_initialized():
+                # same remark as in _init_cooperator_data()
+                continue
+            if not company.property_cooperator_account:
+                company.property_cooperator_account = account_account_model.create(
+                    {
+                        "code": "416101",
+                        "name": "Cooperators",
+                        "user_type_id": receivable_account_type.id,
+                        "reconcile": True,
+                        "company_id": company.id,
+                    }
+                )

--- a/cooperator/models/company.py
+++ b/cooperator/models/company.py
@@ -8,6 +8,7 @@ from odoo import api, fields, models
 
 class ResCompany(models.Model):
     _inherit = "res.company"
+    _check_company_auto = True
 
     def _compute_base_logo(self):
         base_url = self.env["ir.config_parameter"].sudo().get_param("web.base.url")
@@ -43,11 +44,13 @@ class ResCompany(models.Model):
         " the default one as the"
         " receivable account for the"
         " cooperators",
+        check_company=True,
     )
     subscription_journal_id = fields.Many2one(
         "account.journal",
         "Subscription Journal",
         readonly=True,
+        check_company=True,
     )
     unmix_share_type = fields.Boolean(
         string="Unmix share type",

--- a/cooperator/models/operation_request.py
+++ b/cooperator/models/operation_request.py
@@ -54,14 +54,14 @@ class OperationRequest(models.Model):
     share_product_id = fields.Many2one(
         "product.product",
         string="Share type",
-        domain=[("is_share", "=", True)],
+        domain="[('is_share', '=', True), ('company_id', 'in', (company_id, False))]",
         required=True,
         check_company=True,
     )
     share_to_product_id = fields.Many2one(
         "product.product",
         string="Convert to this share type",
-        domain=[("is_share", "=", True)],
+        domain="[('is_share', '=', True), ('company_id', 'in', (company_id, False))]",
         check_company=True,
     )
     share_short_name = fields.Char(

--- a/cooperator/models/operation_request.py
+++ b/cooperator/models/operation_request.py
@@ -12,6 +12,7 @@ from odoo.exceptions import ValidationError
 class OperationRequest(models.Model):
     _name = "operation.request"
     _description = "Operation request"
+    _check_company_auto = True
 
     def get_date_now(self):
         # fixme odoo 12 uses date types
@@ -55,11 +56,13 @@ class OperationRequest(models.Model):
         string="Share type",
         domain=[("is_share", "=", True)],
         required=True,
+        check_company=True,
     )
     share_to_product_id = fields.Many2one(
         "product.product",
         string="Convert to this share type",
         domain=[("is_share", "=", True)],
+        check_company=True,
     )
     share_short_name = fields.Char(
         related="share_product_id.short_name", string="Share type name"
@@ -95,6 +98,7 @@ class OperationRequest(models.Model):
         string="Responsible",
         readonly=True,
         default=lambda self: self.env.user,
+        check_company=True,
     )
     subscription_request = fields.One2many(
         "subscription.request",
@@ -116,7 +120,7 @@ class OperationRequest(models.Model):
         default=lambda self: self.env.company,
     )
 
-    invoice = fields.Many2one("account.move", string="Invoice")
+    invoice = fields.Many2one("account.move", string="Invoice", check_company=True)
 
     @api.constrains("effective_date")
     def _constrain_effective_date(self):
@@ -386,6 +390,7 @@ class OperationRequest(models.Model):
                     "share_product_id": self.share_product_id.id,
                     "share_unit_price": self.share_unit_price,
                     "effective_date": effective_date,
+                    "company_id": self.company_id.id,
                 }
             )
             values["partner_id_to"] = self.partner_id_to.id

--- a/cooperator/models/product.py
+++ b/cooperator/models/product.py
@@ -9,16 +9,6 @@ from odoo import fields, models
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
-    def _default_company_id(self):
-        # when creating a share, the company_id field in the form should be
-        # set by default to the current company, while allowing to set it to
-        # any other value (including none). this seems to work, but is this
-        # the right way to do it? is there a way to set default_company_id to
-        # the current company in the context of the act_window?
-        if self.env.context.get("default_is_share"):
-            return self.env.company
-        return False
-
     is_share = fields.Boolean(string="Is share?")
     short_name = fields.Char(string="Short name")
     display_on_website = fields.Boolean(string="Display on website")
@@ -28,7 +18,6 @@ class ProductTemplate(models.Model):
     by_company = fields.Boolean(string="Can be subscribed by companies?")
     by_individual = fields.Boolean(string="Can be subscribed by individuals?")
     mail_template = fields.Many2one("mail.template", string="Mail template")
-    company_id = fields.Many2one("res.company", default=_default_company_id)
 
     def get_web_share_products(self, is_company):
         if is_company is True:

--- a/cooperator/models/product.py
+++ b/cooperator/models/product.py
@@ -9,6 +9,16 @@ from odoo import fields, models
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
+    def _default_company_id(self):
+        # when creating a share, the company_id field in the form should be
+        # set by default to the current company, while allowing to set it to
+        # any other value (including none). this seems to work, but is this
+        # the right way to do it? is there a way to set default_company_id to
+        # the current company in the context of the act_window?
+        if self.env.context.get("default_is_share"):
+            return self.env.company
+        return False
+
     is_share = fields.Boolean(string="Is share?")
     short_name = fields.Char(string="Short name")
     display_on_website = fields.Boolean(string="Display on website")
@@ -18,6 +28,7 @@ class ProductTemplate(models.Model):
     by_company = fields.Boolean(string="Can be subscribed by companies?")
     by_individual = fields.Boolean(string="Can be subscribed by individuals?")
     mail_template = fields.Many2one("mail.template", string="Mail template")
+    company_id = fields.Many2one("res.company", default=_default_company_id)
 
     def get_web_share_products(self, is_company):
         if is_company is True:

--- a/cooperator/models/share_line.py
+++ b/cooperator/models/share_line.py
@@ -8,6 +8,7 @@ from odoo import fields, models
 class ShareLine(models.Model):
     _name = "share.line"
     _description = "Share line"
+    _check_company_auto = True
 
     def _compute_total_line(self):
         res = {}
@@ -16,7 +17,11 @@ class ShareLine(models.Model):
         return res
 
     share_product_id = fields.Many2one(
-        "product.product", string="Share type", required=True, readonly=True
+        "product.product",
+        string="Share type",
+        required=True,
+        readonly=True,
+        check_company=True,
     )
     share_number = fields.Integer(
         string="Number of Share", required=True, readonly=True

--- a/cooperator/models/subscription_register.py
+++ b/cooperator/models/subscription_register.py
@@ -15,6 +15,7 @@ def _lang_get(self):
 class SubscriptionRegister(models.Model):
     _name = "subscription.register"
     _description = "Subscription register"
+    _check_company_auto = True
 
     def _compute_total_line(self):
         for line in self:
@@ -48,6 +49,7 @@ class SubscriptionRegister(models.Model):
         required=True,
         readonly=True,
         domain=[("is_share", "=", True)],
+        check_company=True,
     )
     share_short_name = fields.Char(
         related="share_product_id.short_name",
@@ -59,6 +61,7 @@ class SubscriptionRegister(models.Model):
         string="Share to type",
         readonly=True,
         domain=[("is_share", "=", True)],
+        check_company=True,
     )
     share_to_short_name = fields.Char(
         related="share_to_product_id.short_name",
@@ -100,6 +103,7 @@ class SubscriptionRegister(models.Model):
         string="Responsible",
         readonly=True,
         default=lambda self: self.env.user,
+        check_company=True,
     )
 
     _order = "register_number_operation asc"

--- a/cooperator/models/subscription_request.py
+++ b/cooperator/models/subscription_request.py
@@ -537,25 +537,15 @@ class SubscriptionRequest(models.Model):
 
     @api.model
     def create_journal(self, company):
-        if company.subscription_journal_id or (
-            not company.chart_template_id
-            and not self.env["account.chart.template"].existing_accounting(company)
-        ):
-            # do not create the journal if it already exists. if it does not
-            # exist, but no account chart template has been loaded yet and no
-            # accounting data exists, then it should not be created either
-            # because all existing journals will be deleted when the account
-            # chart template will be loaded. this method will be called again
-            # when the journals will be created by the account chart template.
-            return
-        company.subscription_journal_id = self.env["account.journal"].create(
-            {
-                "name": _("Subscription Journal"),
-                "code": _("SUBJ"),
-                "type": "sale",
-                "company_id": company.id,
-            }
-        )
+        if not company.subscription_journal_id:
+            company.subscription_journal_id = self.env["account.journal"].create(
+                {
+                    "name": _("Subscription Journal"),
+                    "code": _("SUBJ"),
+                    "type": "sale",
+                    "company_id": company.id,
+                }
+            )
 
     def get_journal(self):
         return self.company_id.subscription_journal_id

--- a/cooperator/models/subscription_request.py
+++ b/cooperator/models/subscription_request.py
@@ -257,7 +257,7 @@ class SubscriptionRequest(models.Model):
     share_product_id = fields.Many2one(
         "product.product",
         string="Share type",
-        domain=[("is_share", "=", True)],
+        domain="[('is_share', '=', True), ('company_id', 'in', (company_id, False))]",
         required=True,
         readonly=True,
         states={"draft": [("readonly", False)]},

--- a/cooperator/models/subscription_request.py
+++ b/cooperator/models/subscription_request.py
@@ -257,6 +257,11 @@ class SubscriptionRequest(models.Model):
     share_product_id = fields.Many2one(
         "product.product",
         string="Share type",
+        # the company_id condition ensures that only shares available for the
+        # company to which this subscription request is linked will be
+        # displayed in the form. this is useful for users that have access to
+        # multiple companies and create subscription requests for the
+        # non-current company.
         domain="[('is_share', '=', True), ('company_id', 'in', (company_id, False))]",
         required=True,
         readonly=True,
@@ -513,6 +518,9 @@ class SubscriptionRequest(models.Model):
 
     def _prepare_invoice_line(self, product, partner, qty):
         self.ensure_one()
+        # .with_company() is needed to allow to validate a subscription
+        # request for a company other than the current one, which can happen
+        # when a user is "logged in" to multiple companies.
         product = product.with_company(self.company_id)
         account = (
             product.property_account_income_id

--- a/cooperator/models/subscription_request.py
+++ b/cooperator/models/subscription_request.py
@@ -535,8 +535,30 @@ class SubscriptionRequest(models.Model):
         }
         return res
 
+    @api.model
+    def create_journal(self, company):
+        if company.subscription_journal_id or (
+            not company.chart_template_id
+            and not self.env["account.chart.template"].existing_accounting(company)
+        ):
+            # do not create the journal if it already exists. if it does not
+            # exist, but no account chart template has been loaded yet and no
+            # accounting data exists, then it should not be created either
+            # because all existing journals will be deleted when the account
+            # chart template will be loaded. this method will be called again
+            # when the journals will be created by the account chart template.
+            return
+        company.subscription_journal_id = self.env["account.journal"].create(
+            {
+                "name": _("Subscription Journal"),
+                "code": _("SUBJ"),
+                "type": "sale",
+                "company_id": company.id,
+            }
+        )
+
     def get_journal(self):
-        return self.env.ref("cooperator.subscription_journal")
+        return self.company_id.subscription_journal_id
 
     def get_accounting_account(self):
         account = self.company_id.property_cooperator_account

--- a/cooperator/readme/newsfragments/77.feature.rst
+++ b/cooperator/readme/newsfragments/77.feature.rst
@@ -1,0 +1,2 @@
+Improve multi-company consistency by setting ``company_id`` on records where
+needed and adding the ``check_company`` flag on ``Many2one`` fields.

--- a/cooperator/tests/cooperator_test_mixin.py
+++ b/cooperator/tests/cooperator_test_mixin.py
@@ -9,43 +9,8 @@ class CooperatorTestMixin:
     @classmethod
     def set_up_cooperator_test_data(cls):
         cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
-        # accounting data needs to be created even if created in module data
-        # because when launching tests, accounting data will be deleted when odoo loads
-        # a test chart of account.
-        # cf _load in chart_template.py in account module
-
-        account_model = cls.env["account.account"]
-        cls.company = cls.env.user.company_id
-        cls.company.coop_email_contact = "coop_email@example.org"
+        cls.env.company.coop_email_contact = "coop_email@example.org"
         cls.demo_partner = cls.env.ref("base.partner_demo")
-
-        receivable_account_type = cls.env.ref("account.data_account_type_receivable")
-        equity_account_type = cls.env.ref("account.data_account_type_equity")
-        cooperator_account = account_model.create(
-            {
-                "name": "Cooperator Test",
-                "code": "416109",
-                "user_type_id": receivable_account_type.id,
-                "reconcile": True,
-            }
-        )
-        cls.company.property_cooperator_account = cooperator_account
-        cls.equity_account = account_model.create(
-            {
-                "name": "Equity Test ",
-                "code": "100919",
-                "user_type_id": equity_account_type.id,
-                "reconcile": True,
-            }
-        )
-        cls.subscription_journal = cls.env["account.journal"].create(
-            {
-                "name": "Subscriptions Test",
-                "code": "SUBJT",
-                "type": "sale",
-            }
-        )
-
         cls.share_x = cls.env["product.product"].create(
             {
                 "name": "Share X - Founder",
@@ -133,7 +98,7 @@ class CooperatorTestMixin:
                         0,
                         {
                             "name": invoice.payment_reference,
-                            "account_id": self.company.property_cooperator_account.id,
+                            "account_id": self.env.company.property_cooperator_account.id,
                             "credit": amount,
                         },
                     ),

--- a/cooperator/tests/cooperator_test_mixin.py
+++ b/cooperator/tests/cooperator_test_mixin.py
@@ -9,7 +9,8 @@ class CooperatorTestMixin:
     @classmethod
     def set_up_cooperator_test_data(cls):
         cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
-        cls.env.company.coop_email_contact = "coop_email@example.org"
+        cls.company = cls.env.company
+        cls.company.coop_email_contact = "coop_email@example.org"
         cls.demo_partner = cls.env.ref("base.partner_demo")
         cls.share_x = cls.env["product.product"].create(
             {
@@ -98,7 +99,7 @@ class CooperatorTestMixin:
                         0,
                         {
                             "name": invoice.payment_reference,
-                            "account_id": self.env.company.property_cooperator_account.id,
+                            "account_id": self.company.property_cooperator_account.id,
                             "credit": amount,
                         },
                     ),
@@ -181,5 +182,5 @@ class CooperatorTestMixin:
             }
         )
         # apply the same account chart template as the main company
-        self.env.company.chart_template_id.try_loading(company)
+        self.company.chart_template_id.try_loading(company)
         return company

--- a/cooperator/tests/cooperator_test_mixin.py
+++ b/cooperator/tests/cooperator_test_mixin.py
@@ -173,3 +173,13 @@ class CooperatorTestMixin:
         )
         self.validate_subscription_request_and_pay(subscription_request)
         return partner
+
+    def create_company(self, name):
+        company = self.env["res.company"].create(
+            {
+                "name": name,
+            }
+        )
+        # apply the same account chart template as the main company
+        self.env.company.chart_template_id.try_loading(company)
+        return company

--- a/cooperator/tests/test_cooperator.py
+++ b/cooperator/tests/test_cooperator.py
@@ -4,7 +4,7 @@
 
 from datetime import date, datetime, timedelta
 
-from odoo.exceptions import AccessError
+from odoo.exceptions import AccessError, UserError
 from odoo.fields import Date
 from odoo.tests.common import SavepointCase, users
 
@@ -549,3 +549,79 @@ class CooperatorCase(SavepointCase, CooperatorTestMixin):
         self.assertEqual(
             subscription_request_2.get_journal(), company_2.subscription_journal_id
         )
+
+    def test_create_subscription_request_with_share_of_different_company(self):
+        """
+        Test that creating a subscription request with a share (product)
+        linked to a different company than the current one fails.
+        """
+        # link the share to a specific company (instead of it being shared
+        # across all of them).
+        self.share_y.company_id = self.company.id
+        company_2 = self.create_company("company 2")
+        with self.assertRaises(UserError):
+            self.env["subscription.request"].with_company(company_2).create(
+                self.get_dummy_subscription_requests_vals()
+            )
+
+    def test_create_operation_request_with_share_of_different_company(self):
+        """
+        Test that creating an operation request with a share (product)
+        linked to a different company than the current one fails.
+        """
+        # link the share to a specific company (instead of it being shared
+        # across all of them).
+        self.share_y.company_id = self.company.id
+        company_2 = self.create_company("company 2")
+        vals = {
+            "partner_id": self.demo_partner.id,
+            "operation_type": "sell_back",
+            "share_product_id": self.share_y.id,
+            "quantity": 2,
+        }
+        with self.assertRaises(UserError):
+            self.env["operation.request"].with_company(company_2).create(vals)
+        vals.update(
+            {
+                "share_product_id": self.share_x.id,
+                "share_to_product_id": self.share_y.id,
+            }
+        )
+        with self.assertRaises(UserError):
+            self.env["operation.request"].with_company(company_2).create(vals)
+
+    def test_create_cooperator_for_other_company(self):
+        """
+        Test that creating a cooperator for a different company works and
+        keeps data correctly separated per company.
+        """
+        company_2 = self.create_company("company 2")
+        subscription_request = (
+            self.env["subscription.request"]
+            .with_company(company_2)
+            .create(self.get_dummy_subscription_requests_vals())
+        )
+        self.validate_subscription_request_and_pay(subscription_request)
+        invoice = subscription_request.capital_release_request
+        self.assertEqual(invoice.company_id, company_2)
+
+        partner = subscription_request.partner_id
+        self.assertFalse(partner.coop_candidate)
+        self.assertTrue(partner.member)
+        self.assertTrue(partner.share_ids)
+
+    def test_create_cooperator_for_non_current_company(self):
+        """
+        Test that creating a cooperator for a different company than the
+        current one works and keeps data correctly separated per company.
+        """
+        company_2 = self.create_company("company 2")
+        subscription_request = (
+            self.env["subscription.request"]
+            .with_company(company_2)
+            .create(self.get_dummy_subscription_requests_vals())
+        )
+        subscription_request.with_company(self.company).validate_subscription_request()
+        invoice = subscription_request.capital_release_request
+        self.assertEqual(invoice.company_id, company_2)
+        self.pay_invoice(invoice)

--- a/cooperator/tests/test_cooperator.py
+++ b/cooperator/tests/test_cooperator.py
@@ -516,3 +516,36 @@ class CooperatorCase(SavepointCase, CooperatorTestMixin):
         subscription_request = self.env["subscription.request"].create(vals)
         partner = subscription_request.partner_id
         self.assertNotEqual(partner, company_partner)
+
+    def test_subscription_journal_per_company(self):
+        """
+        Test that creating a new company creates a new subscription journal
+        for it.
+        """
+        company_1 = self.env.company
+        company_2 = self.create_company("company 2")
+        self.assertTrue(company_2.subscription_journal_id)
+        self.assertEqual(company_2.subscription_journal_id.company_id, company_2)
+        self.assertNotEqual(
+            company_1.subscription_journal_id, company_2.subscription_journal_id
+        )
+
+    def test_subscription_request_journal_per_company(self):
+        company_1 = self.env.company
+        company_2 = self.create_company("company 2")
+        subscription_request_1 = self.env["subscription.request"].create(
+            self.get_dummy_subscription_requests_vals()
+        )
+        subscription_request_2 = (
+            self.env["subscription.request"]
+            .with_company(company_2)
+            .create(self.get_dummy_subscription_requests_vals())
+        )
+        self.assertEqual(subscription_request_1.company_id, company_1)
+        self.assertEqual(subscription_request_2.company_id, company_2)
+        self.assertEqual(
+            subscription_request_1.get_journal(), company_1.subscription_journal_id
+        )
+        self.assertEqual(
+            subscription_request_2.get_journal(), company_2.subscription_journal_id
+        )

--- a/cooperator/tests/test_cooperator.py
+++ b/cooperator/tests/test_cooperator.py
@@ -522,7 +522,7 @@ class CooperatorCase(SavepointCase, CooperatorTestMixin):
         Test that creating a new company creates a new subscription journal
         for it.
         """
-        company_1 = self.env.company
+        company_1 = self.company
         company_2 = self.create_company("company 2")
         self.assertTrue(company_2.subscription_journal_id)
         self.assertEqual(company_2.subscription_journal_id.company_id, company_2)
@@ -531,7 +531,7 @@ class CooperatorCase(SavepointCase, CooperatorTestMixin):
         )
 
     def test_subscription_request_journal_per_company(self):
-        company_1 = self.env.company
+        company_1 = self.company
         company_2 = self.create_company("company 2")
         subscription_request_1 = self.env["subscription.request"].create(
             self.get_dummy_subscription_requests_vals()

--- a/cooperator/views/operation_request_view.xml
+++ b/cooperator/views/operation_request_view.xml
@@ -12,6 +12,7 @@
                 <field name="quantity" />
                 <field name="user_id" />
                 <field name="state" />
+                <field name="company_id" groups="base.group_multi_company" />
             </tree>
         </field>
     </record>
@@ -115,6 +116,11 @@
                             />
                             <field name="share_unit_price" readonly="True" />
                             <field name="subscription_amount" readonly="True" />
+                            <field
+                                name="company_id"
+                                groups="base.group_multi_company"
+                                attrs="{'readonly': [('id', '!=', False)]}"
+                            />
                         </group>
                     </group>
                     <group>
@@ -160,6 +166,11 @@
                                             <field name="state" invisible="True" />
                                             <field
                                                 name="share_product_id"
+                                                invisible="True"
+                                            />
+                                            <field
+                                                name="company_id"
+                                                groups="base.group_multi_company"
                                                 invisible="True"
                                             />
                                         </group>

--- a/cooperator/views/product_view.xml
+++ b/cooperator/views/product_view.xml
@@ -80,7 +80,9 @@
         <field name="search_view_id" eval="False" /> <!-- Force empty -->
         <field name="view_id" eval="False" /> <!-- Force empty -->
         <field name="domain">[('is_share','=',True)]</field>
-        <field name="context">{"default_is_share": True}</field>
+        <field
+            name="context"
+        >{"default_is_share": True, "default_company_id": allowed_company_ids[0]}</field>
         <field name="help" type="html">
             <p class="oe_view_nocontent_create">
                 Click to define a new share product.

--- a/cooperator/views/product_view.xml
+++ b/cooperator/views/product_view.xml
@@ -80,6 +80,7 @@
         <field name="search_view_id" eval="False" /> <!-- Force empty -->
         <field name="view_id" eval="False" /> <!-- Force empty -->
         <field name="domain">[('is_share','=',True)]</field>
+        <field name="context">{"default_is_share": True}</field>
         <field name="help" type="html">
             <p class="oe_view_nocontent_create">
                 Click to define a new share product.

--- a/cooperator/views/subscription_register_view.xml
+++ b/cooperator/views/subscription_register_view.xml
@@ -12,6 +12,7 @@
                 <field name="share_unit_price" />
                 <field name="total_amount_line" sum="Total amount" />
                 <field name="type" />
+                <field name="company_id" groups="base.group_multi_company" />
             </tree>
         </field>
     </record>
@@ -41,6 +42,7 @@
                         <field name="quantity_to" />
                         <field name="share_to_unit_price" />
                         <field name="user_id" invisible="True" />
+                        <field name="company_id" groups="base.group_multi_company" />
                     </group>
                 </group>
             </form>

--- a/cooperator/views/subscription_request_view.xml
+++ b/cooperator/views/subscription_request_view.xml
@@ -24,6 +24,7 @@
                 <field name="source" />
                 <field name="state" />
                 <field name="is_valid_iban" invisible="True" />
+                <field name="company_id" groups="base.group_multi_company" />
                 <button
                     type="object"
                     string="Validate"
@@ -155,6 +156,11 @@
                             <field name="data_policy_approved" />
                             <field name="financial_risk_approved" />
                             <field name="generic_rules_approved" />
+                            <field
+                                name="company_id"
+                                groups="base.group_multi_company"
+                                attrs="{'readonly': [('id', '!=', False)]}"
+                            />
                         </group>
                     </group>
                     <notebook>

--- a/cooperator/wizard/create_subscription_from_partner.xml
+++ b/cooperator/wizard/create_subscription_from_partner.xml
@@ -34,6 +34,7 @@
                     <field name="share_qty" />
                     <field name="share_unit_price" />
                     <field name="subscription_amount" />
+                    <field name="company_id" groups="base.group_multi_company" />
                 </group>
                 <footer>
                     <button


### PR DESCRIPTION
this is part of the current effort aiming to make `cooperator` multi-company compatible.

correct multi-company cooperator membership information is not handled by this. it will be handled in a separate branch.

this branch is currently based on top of #75, because it depends on those changes. only the last 5 commits are only part of this branch.

@enricostano @DaniilDigtyar