### PR TITLE
[14.0][FIX] l10n_be_cooperator: Remove space characters from e-mail fields in template

### DIFF
--- a/l10n_be_cooperator/data/mail_template_data.xml
+++ b/l10n_be_cooperator/data/mail_template_data.xml
@@ -5,14 +5,14 @@
     <data noupdate="1">
         <record id="email_template_tax_shelter_certificate" model="mail.template">
             <field name="name">Tax Shelter Certificate - Send By Email</field>
-            <field name="email_from">
-                ${(object.company_id.coop_email_contact or object.company_id.partner_id.email)|safe}
-            </field>
+            <field
+                name="email_from"
+            >${(object.company_id.coop_email_contact or object.company_id.partner_id.email)|safe}</field>
             <field name="subject">Tax Shelter Certificate</field>
             <field name="partner_to">${object.partner_id.id}</field>
-            <field name="reply_to">
-                ${(object.company_id.coop_email_contact or object.company_id.partner_id.email)|safe}
-            </field>
+            <field
+                name="reply_to"
+            >${(object.company_id.coop_email_contact or object.company_id.partner_id.email)|safe}</field>
             <field name="model_id" ref="model_tax_shelter_certificate" />
             <field name="auto_delete" eval="True" />
             <field name="lang">${object.partner_id.lang}</field>


### PR DESCRIPTION
move OCA/l10n-belgium#184 to here, as the `l10n_be_cooperator` module has been moved to here.