### PR TITLE
[14.0][IMP] cooperator: domain to get only mail template certificate for model `res.partner`

### DIFF
--- a/cooperator/models/product.py
+++ b/cooperator/models/product.py
@@ -17,7 +17,12 @@ class ProductTemplate(models.Model):
     force_min_qty = fields.Boolean(string="Force minimum quantity?")
     by_company = fields.Boolean(string="Can be subscribed by companies?")
     by_individual = fields.Boolean(string="Can be subscribed by individuals?")
-    mail_template = fields.Many2one("mail.template", string="Mail template")
+    mail_template = fields.Many2one(
+        comodel_name="mail.template",
+        string="Certificate email template",
+        domain=[("model", "=", "res.partner"), ("is_cooperator_template", "=", True)],
+        help="If left empty, the default global mail template will be used.",
+    )
 
     def get_web_share_products(self, is_company):
         if is_company is True:


### PR DESCRIPTION
Appling the same domain as the `cooperator_certificate_mail_template` in [`res.company`](https://github.com/OCA/cooperative/blob/14.0/cooperator/models/company.py#L114) for the `mail_template` in `product.template`.

Without the domain you can select any mail template, causing an error when selecting a mail template that is not configured for `res.partner` models.

Also changed the `name` and `help` to reflect an expected certificate email.