### PR TITLE
[14.0][FIX] Replace fixed ordered_parts value with dynamic

### DIFF
--- a/cooperator_website/views/subscription_template.xml
+++ b/cooperator_website/views/subscription_template.xml
@@ -368,7 +368,7 @@
                         id="ordered_parts"
                         step="1"
                         min="1"
-                        value="1"
+                        t-attf-value="#{ordered_parts}"
                         class="form-control form-control-sm"
                     />
                 </div>


### PR DESCRIPTION
When you fill a subscription request and try to send the form having indicated more than one `share (ordered_parts field)`, in the case of rerendering, for example if you make a mistake and the  value of confirm_email does not match the value of email, the form is rerendered with all the previously filled values except from the value of `ordered_parts` which gets reset to 1.

This pull request replaces the fixed `value` attribute with the `t-attf-value` attribute in order to rerender the filled value as in the rest of the fields.