### PR TITLE
[16.0][IMP] Set birthdate to required on sub request

### DIFF
--- a/cooperator/demo/coop.xml
+++ b/cooperator/demo/coop.xml
@@ -15,6 +15,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
         <field name="street">Avenue des Dessus-de-Livres, 2</field>
         <field name="city">Namur (Loyers)</field>
         <field name="zip">5101</field>
+        <field name="birthdate_date">1980-01-01</field>
         <field name="country_id" ref="base.be" />
     </record>
 
@@ -39,6 +40,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
         <field name="street">Avenue des Dessous-de-Livres, 3</field>
         <field name="city">Namur (Loyers)</field>
         <field name="zip">5101</field>
+        <field name="birthdate_date">1980-01-01</field>
         <field name="country_id" ref="base.be" />
     </record>
 
@@ -62,6 +64,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
         <field name="street">Rue de la colocation, 23</field>
         <field name="city">Namur (Loyers)</field>
         <field name="zip">5101</field>
+        <field name="birthdate_date">1990-01-01</field>
         <field name="country_id" ref="base.be" />
     </record>
 
@@ -77,6 +80,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
         <field name="email">remy@demo.net</field>
         <field name="street">Rue Guido Van Rossum, 2</field>
         <field name="city">Evere</field>
+        <field name="birthdate_date">1992-10-01</field>
         <field name="zip">5101</field>
         <field name="country_id" ref="base.be" />
     </record>
@@ -164,6 +168,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
             eval="obj(ref('product_template_share_type_1_demo')).product_variant_id.id"
         />
         <field name="lang">en_US</field>
+        <field name="birthdate">1990-12-21</field>
         <field name="skip_iban_control" eval="True" />
         <field name="state">waiting</field>
         <field name="data_policy_approved" eval="True" />

--- a/cooperator/models/subscription_request.py
+++ b/cooperator/models/subscription_request.py
@@ -211,6 +211,7 @@ class SubscriptionRequest(models.Model):
     birthdate = fields.Date(
         string="Date of birth",
         readonly=True,
+        required=True,
         states={"draft": [("readonly", False)]},
     )
     gender = fields.Selection(


### PR DESCRIPTION
The birthdate is necessary for some later cooperator actions, so it must be set as required.
~~It is set in the view and not in python because it must be compatible with previous data for wich birthdate might not have been set.~~

internal task : https://gestion.coopiteasy.be/web#id=8127&action=475&active_id=524&model=project.task&view_type=form&menu_id=