### PR TITLE
[14.0][IMP] cooperator: subscription creates partners with company_id

### DIFF
--- a/cooperator/models/subscription_request.py
+++ b/cooperator/models/subscription_request.py
@@ -633,6 +633,7 @@ class SubscriptionRequest(models.Model):
             "email": self.company_email,
             "country_id": self.country_id.id,
             "lang": self.lang,
+            "company_id": self.company_id.id,
             "cooperative_membership_ids": [
                 (
                     0,
@@ -664,6 +665,7 @@ class SubscriptionRequest(models.Model):
             "country_id": self.country_id.id,
             "lang": self.lang,
             "birthdate_date": self.birthdate,
+            "company_id": self.company_id.id,
             "cooperative_membership_ids": [
                 (
                     0,
@@ -700,6 +702,7 @@ class SubscriptionRequest(models.Model):
             "representative": True,
             "function": self.contact_person_function,
             "type": "representative",
+            "company_id": self.company_id.id,
             "cooperative_membership_ids": [
                 (
                     0,

--- a/cooperator/tests/test_cooperator.py
+++ b/cooperator/tests/test_cooperator.py
@@ -691,6 +691,7 @@ class CooperatorCase(SavepointCase, CooperatorTestMixin):
         )
         self.validate_subscription_request_and_pay(subscription_request_1)
         partner_1 = subscription_request_1.partner_id
+        partner_1.company_id = False
         company_2 = self.company_2
         company_2.create_user = True
         subscription_request_2 = (


### PR DESCRIPTION
When the `subscription.request` creates a new `res.partner` it doesn't assign any `company_id` to the values so it is visible for all companies.

The model `res.partner` doesn't assign any `company_id` by default, so we should set it in `cooperator`.