### PR TITLE
[14.0] dotfiles update needs manual intervention

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.19.2
+_commit: v1.21.1
 _src_path: git+https://github.com/oca/oca-addons-repo-template
 ci: GitHub
 convert_readme_fragments_to_markdown: false

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Stale PRs and issues policy
-        uses: actions/stale@v4
+        uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           # General settings.
@@ -48,7 +48,7 @@ jobs:
       # * Issues that are pending more information
       # * Except Issues marked as "no stale"
       - name: Needs more information stale issues policy
-        uses: actions/stale@v4
+        uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           ascending: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,9 @@ jobs:
         run: oca_init_test_database
       - name: Run tests
         run: oca_run_tests
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Update .pot files
         run: oca_export_and_push_pot https://x-access-token:${{ secrets.GIT_PUSH_TOKEN }}@github.com/${{ github.repository }}
         if: ${{ matrix.makepot == 'true' && github.event_name == 'push' && github.repository_owner == 'OCA' }}

--- a/.oca_hooks.cfg
+++ b/.oca_hooks.cfg
@@ -1,0 +1,2 @@
+[MESSAGES_CONTROL]
+disable=xml-deprecated-data-node,xml-deprecated-tree-attribute

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,8 @@ exclude: |
   readme/.*\.(rst|md)$|
   # Ignore build and dist directories in addons
   /build/|/dist/|
+  # Ignore test files in addons
+  /tests/samples/.*|
   # You don't usually want a bot to modify your legal texts
   (LICENSE.*|COPYING.*)
 default_language_version:
@@ -37,7 +39,7 @@ repos:
         language: fail
         files: '[a-zA-Z0-9_]*/i18n/en\.po$'
   - repo: https://github.com/oca/maintainer-tools
-    rev: f71041f22b8cd68cf7c77b73a14ca8d8cd190a60
+    rev: 9a170331575a265c092ee6b24b845ec508e8ef75
     hooks:
       # update the NOT INSTALLABLE ADDONS section above
       - id: oca-update-pre-commit-excluded-addons

--- a/cooperator/README.rst
+++ b/cooperator/README.rst
@@ -134,7 +134,7 @@ Changelog
 
 **Features**
 
-- Rework ``res.partner`` form view as has been done in version 16. (`#105 <https://github.com/OCA/cooperative/issues/105>`_)
+- Rework ``res.partner`` form view as has been done in version 16. (#105)
 
 
 **Bugfixes**

--- a/cooperator/readme/HISTORY.rst
+++ b/cooperator/readme/HISTORY.rst
@@ -3,7 +3,7 @@
 
 **Features**
 
-- Rework ``res.partner`` form view as has been done in version 16. (`#105 <https://github.com/OCA/cooperative/issues/105>`_)
+- Rework ``res.partner`` form view as has been done in version 16. (#105)
 
 
 **Bugfixes**

--- a/cooperator/static/description/index.html
+++ b/cooperator/static/description/index.html
@@ -475,7 +475,7 @@ memberships of all companies or only the ones in which the user is â€œlogged inâ
 <h2><a class="toc-backref" href="#toc-entry-5">14.0.2.1.0 (2024-04-15)</a></h2>
 <p><strong>Features</strong></p>
 <ul class="simple">
-<li>Rework <tt class="docutils literal">res.partner</tt> form view as has been done in version 16. (<a class="reference external" href="https://github.com/OCA/cooperative/issues/105">#105</a>)</li>
+<li>Rework <tt class="docutils literal">res.partner</tt> form view as has been done in version 16. (#105)</li>
 </ul>
 <p><strong>Bugfixes</strong></p>
 <ul class="simple">


### PR DESCRIPTION
Dear maintainer,

After updating the dotfiles, `pre-commit run -a`
fails in a manner that cannot be resolved automatically.

Can you please have a look, fix and merge?

Thanks,
