### PR TITLE
[16.0][FIX] validate belgian national register number before subscription request

### DIFF
--- a/l10n_be_cooperator_national_number/__init__.py
+++ b/l10n_be_cooperator_national_number/__init__.py
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: 2023 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from . import models

--- a/l10n_be_cooperator_national_number/models/__init__.py
+++ b/l10n_be_cooperator_national_number/models/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from . import company
 from . import subscription_request
 from . import res_partner

--- a/l10n_be_cooperator_national_number/models/company.py
+++ b/l10n_be_cooperator_national_number/models/company.py
@@ -1,7 +1,6 @@
-# Copyright 2019 Coop IT Easy SCRL fs
-#   Houssine Bakkali <houssine@coopiteasy.be>
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
-
+# SPDX-FileCopyrightText: 2023 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError

--- a/l10n_be_cooperator_national_number/models/subscription_request.py
+++ b/l10n_be_cooperator_national_number/models/subscription_request.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from collections import namedtuple
 
 from odoo import _, api, fields, models

--- a/l10n_be_cooperator_national_number/models/subscription_request.py
+++ b/l10n_be_cooperator_national_number/models/subscription_request.py
@@ -1,3 +1,5 @@
+from collections import namedtuple
+
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
@@ -25,19 +27,38 @@ class SubscriptionRequest(models.Model):
             self.company_id.require_national_number and not self.is_company
         )
 
-    def get_national_number_from_partner(self, partner):
-        national_number_id_category = self.env.ref(
+    @api.model
+    def _get_be_national_register_number_id_category(self):
+        return self.env.ref(
             "l10n_be_partner_identification.l10n_be_national_registry_number_category"
-        ).id
+        )
+
+    @api.model
+    def get_national_number_from_partner(self, partner):
+        national_number_id_category = (
+            self._get_be_national_register_number_id_category()
+        )
         national_number = partner.id_numbers.filtered(
-            lambda rec: rec.category_id.id == national_number_id_category
+            lambda rec: rec.category_id.id == national_number_id_category.id
         )
         return national_number.name
+
+    @api.model
+    def check_be_national_register_number(self, national_number):
+        national_number_id_category = (
+            self._get_be_national_register_number_id_category()
+        )
+        # this function checks the value of id_number.name, not id_number
+        # directly.
+        id_number = namedtuple("id_number", ("name"))(national_number)
+        national_number_id_category.validate_id_number(id_number)
 
     def validate_subscription_request(self):
         self.ensure_one()
         if self.require_national_number and not self.national_number:
             raise UserError(_("National Number is required."))
+        if self.national_number:
+            self.check_be_national_register_number(self.national_number)
         invoice = super().validate_subscription_request()
         if not self.is_company:
             partner = invoice.partner_id

--- a/l10n_be_cooperator_national_number/tests/__init__.py
+++ b/l10n_be_cooperator_national_number/tests/__init__.py
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: 2023 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from . import test_cooperator_national_number

--- a/l10n_be_cooperator_national_number/tests/test_cooperator_national_number.py
+++ b/l10n_be_cooperator_national_number/tests/test_cooperator_national_number.py
@@ -1,6 +1,6 @@
-# Copyright 2019 Coop IT Easy SCRL fs
-#   Robin Keunen <robin@coopiteasy.be>
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+# SPDX-FileCopyrightText: 2023 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
 
 from unittest import mock
 


### PR DESCRIPTION
check that the belgian national registry number is valid before validating the subscription request, to avoid creating and posting the capital release request and then having it rolled back.