### PR TITLE
[16.0][FIX] validate belgian national register number on website form

### DIFF
--- a/l10n_be_cooperator_national_number/__init__.py
+++ b/l10n_be_cooperator_national_number/__init__.py
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: 2023 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from . import models

--- a/l10n_be_cooperator_national_number/models/__init__.py
+++ b/l10n_be_cooperator_national_number/models/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from . import company
 from . import subscription_request
 from . import res_partner

--- a/l10n_be_cooperator_national_number/models/company.py
+++ b/l10n_be_cooperator_national_number/models/company.py
@@ -1,7 +1,6 @@
-# Copyright 2019 Coop IT Easy SCRL fs
-#   Houssine Bakkali <houssine@coopiteasy.be>
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
-
+# SPDX-FileCopyrightText: 2023 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError

--- a/l10n_be_cooperator_national_number/models/subscription_request.py
+++ b/l10n_be_cooperator_national_number/models/subscription_request.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from collections import namedtuple
 
 from odoo import _, api, fields, models

--- a/l10n_be_cooperator_national_number/models/subscription_request.py
+++ b/l10n_be_cooperator_national_number/models/subscription_request.py
@@ -1,3 +1,5 @@
+from collections import namedtuple
+
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
@@ -25,19 +27,38 @@ class SubscriptionRequest(models.Model):
             self.company_id.require_national_number and not self.is_company
         )
 
-    def get_national_number_from_partner(self, partner):
-        national_number_id_category = self.env.ref(
+    @api.model
+    def _get_be_national_register_number_id_category(self):
+        return self.env.ref(
             "l10n_be_partner_identification.l10n_be_national_registry_number_category"
-        ).id
+        )
+
+    @api.model
+    def get_national_number_from_partner(self, partner):
+        national_number_id_category = (
+            self._get_be_national_register_number_id_category()
+        )
         national_number = partner.id_numbers.filtered(
-            lambda rec: rec.category_id.id == national_number_id_category
+            lambda rec: rec.category_id.id == national_number_id_category.id
         )
         return national_number.name
+
+    @api.model
+    def check_be_national_register_number(self, national_number):
+        national_number_id_category = (
+            self._get_be_national_register_number_id_category()
+        )
+        # this function checks the value of id_number.name, not id_number
+        # directly.
+        id_number = namedtuple("id_number", ("name"))(national_number)
+        national_number_id_category.validate_id_number(id_number)
 
     def validate_subscription_request(self):
         self.ensure_one()
         if self.require_national_number and not self.national_number:
             raise UserError(_("National Number is required."))
+        if self.national_number:
+            self.check_be_national_register_number(self.national_number)
         invoice = super().validate_subscription_request()
         if not self.is_company:
             partner = invoice.partner_id

--- a/l10n_be_cooperator_national_number/tests/__init__.py
+++ b/l10n_be_cooperator_national_number/tests/__init__.py
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: 2023 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from . import test_cooperator_national_number

--- a/l10n_be_cooperator_national_number/tests/test_cooperator_national_number.py
+++ b/l10n_be_cooperator_national_number/tests/test_cooperator_national_number.py
@@ -1,6 +1,6 @@
-# Copyright 2019 Coop IT Easy SCRL fs
-#   Robin Keunen <robin@coopiteasy.be>
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+# SPDX-FileCopyrightText: 2023 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
 
 from unittest import mock
 

--- a/l10n_be_cooperator_website_national_number/README.rst
+++ b/l10n_be_cooperator_website_national_number/README.rst
@@ -39,7 +39,6 @@ Known issues / Roadmap
 ======================
 
 - National number should be editable from the cooperator portal. Indeed, if the national number is required and was not provided on the first subscription, a cooperator will not be able to subscribe more shares from the website form.
-- Note that since the check on the Belgian national number is enforced upon validation, it is possible to submit the request form with an invalid national number.
 
 Bug Tracker
 ===========

--- a/l10n_be_cooperator_website_national_number/controllers/main.py
+++ b/l10n_be_cooperator_website_national_number/controllers/main.py
@@ -1,4 +1,6 @@
+from odoo.exceptions import ValidationError
 from odoo.http import request
+from odoo.tools.translate import _
 
 from odoo.addons.cooperator_website.controllers.main import WebsiteSubscription
 
@@ -19,8 +21,44 @@ class WebsiteSubscription(WebsiteSubscription):
                 values["national_number"] = national_number
         return values
 
+    def _get_display_national_number(self, is_company):
+        if is_company:
+            return False
+        return request.env.company.display_national_number
+
+    def _get_require_national_number(self, is_company):
+        if is_company:
+            return False
+        return request.env.company.require_national_number
+
     def fill_values(self, values, is_company, logged, load_from_user=False):
         values = super().fill_values(values, is_company, logged, load_from_user)
-        if not is_company and request.env.company.require_national_number:
-            values["national_number_required"] = True
+        values["display_national_number"] = self._get_display_national_number(
+            is_company
+        )
+        values["national_number_required"] = self._get_require_national_number(
+            is_company
+        )
         return values
+
+    def _additional_validate(self, kwargs, logged, values, post_file):
+        result = super()._additional_validate(kwargs, logged, values, post_file)
+        if result is not True:
+            return result
+        national_number = values.get("national_number")
+        if national_number:
+            try:
+                # sudo is required to allow access to res.partner.id_category.
+                request.env[
+                    "subscription.request"
+                ].sudo().check_be_national_register_number(values["national_number"])
+                return True
+            except ValidationError as ve:
+                values["error_msg"] = str(ve)
+        else:
+            is_company = kwargs.get("is_company") == "on"
+            if not self._get_require_national_number(is_company):
+                return True
+            values["error_msg"] = _("Some mandatory fields have not been filled.")
+        values["error"] = {"national_number"}
+        return False

--- a/l10n_be_cooperator_website_national_number/readme/ROADMAP.rst
+++ b/l10n_be_cooperator_website_national_number/readme/ROADMAP.rst
@@ -1,2 +1,1 @@
 - National number should be editable from the cooperator portal. Indeed, if the national number is required and was not provided on the first subscription, a cooperator will not be able to subscribe more shares from the website form.
-- Note that since the check on the Belgian national number is enforced upon validation, it is possible to submit the request form with an invalid national number.

--- a/l10n_be_cooperator_website_national_number/static/description/index.html
+++ b/l10n_be_cooperator_website_national_number/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -388,7 +387,6 @@ ul.auto-toc {
 <h1><a class="toc-backref" href="#toc-entry-1">Known issues / Roadmap</a></h1>
 <ul class="simple">
 <li>National number should be editable from the cooperator portal. Indeed, if the national number is required and was not provided on the first subscription, a cooperator will not be able to subscribe more shares from the website form.</li>
-<li>Note that since the check on the Belgian national number is enforced upon validation, it is possible to submit the request form with an invalid national number.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">

--- a/l10n_be_cooperator_website_national_number/views/subscription_template.xml
+++ b/l10n_be_cooperator_website_national_number/views/subscription_template.xml
@@ -1,20 +1,18 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
+
     <template id="national_number_template" name="national_number_template">
-        <div
-            class="form-group field-national_number"
-            t-attf-class="form-group #{error and 'national_number' in error and 'has-error' or ''}"
-            name="national_number_container"
-        >
-            <label for="national_number">National Number</label>
+        <div class="mb-3 field-national_number" name="national_number_container">
+            <label for="national_number" class="form-label">National Number</label>
             <input
-                class="form-control form-control-sm"
-                id="national_number"
-                name="national_number"
+                t-attf-class="form-control form-control-sm{{ error and 'national_number' in error and ' is-invalid' or '' }}"
                 type="text"
-                t-att-readonly="logged"
+                name="national_number"
+                id="national_number"
                 t-att-required="national_number_required"
-                t-attf-value="#{national_number or ''}"
+                t-att-readonly="logged"
+                t-att-value="national_number"
+                placeholder="YY.MM.DD-NNN.CC"
             />
         </div>
     </template>
@@ -29,6 +27,7 @@
             position="after"
         >
             <t
+                t-if="display_national_number"
                 t-call="l10n_be_cooperator_website_national_number.national_number_template"
             />
         </xpath>


### PR DESCRIPTION
*   validate belgian national register number on website form.
*   fix style of belgian national register number field.
*   only display belgian national register number field if `display_national_number` is true.

note that this branch is created on top of #127 (because it depends on it). only the last commit is part of this branch and should be reviewed.