### PR TITLE
[16.0][FIX] fix transfer operation to non-member

### DIFF
--- a/cooperator/models/operation_request.py
+++ b/cooperator/models/operation_request.py
@@ -95,8 +95,8 @@ class OperationRequest(models.Model):
     # list of subscription requests while it is not a real one and it sends an
     # email message to the receiver when it is created. instead, a partner
     # should be created. the problem with using a partner, though, (besides
-    # creating a partner that might never be used if the the operation is
-    # never executed) is that it cannot hold the extra values coming from the
+    # creating a partner that might never be used if the operation is never
+    # executed) is that it cannot hold the extra values coming from the
     # subscription request and not stored on the partner or on the
     # cooperative.membership, like the iban (is it the only one?). should we
     # use a separate model that would be used here and in subscription.request
@@ -105,11 +105,8 @@ class OperationRequest(models.Model):
         "subscription.request",
         "operation_request_id",
         string="Share Receiver Info",
-        help="In case on a transfer of"
-        " share. If the share receiver"
-        " isn't a effective member then a"
-        " subscription form should"
-        " be filled.",
+        help="For transfer operations: if the share receiver isn't a "
+        "(former) member then a subscription form must be filled.",
     )
     receiver_not_member = fields.Boolean(string="Receiver is not a member")
     company_id = fields.Many2one(
@@ -313,6 +310,13 @@ class OperationRequest(models.Model):
             cert_email_template.send_mail(
                 self.partner_id.id, email_layout_xmlid="mail.mail_notification_layout"
             )
+
+    @api.onchange("share_product_id", "quantity")
+    def _onchange_shares(self):
+        for rec in self:
+            for sr in rec.subscription_request:
+                sr.share_product_id = rec.share_product_id
+                sr.ordered_parts = rec.quantity
 
     def get_subscription_register_vals(self, effective_date):
         return {

--- a/cooperator/readme/newsfragments/162.bugfix.rst
+++ b/cooperator/readme/newsfragments/162.bugfix.rst
@@ -1,0 +1,2 @@
+Fix transfer operation to non-member: update share fields values of the internal subscription request of a transfer operation to a non-member when these values are changed in the form.
+This ensures that the values are correct even if the subscription request is created before the values are set.

--- a/cooperator/tests/test_cooperator.py
+++ b/cooperator/tests/test_cooperator.py
@@ -9,7 +9,7 @@ from freezegun import freeze_time
 
 from odoo import fields
 from odoo.exceptions import AccessError, UserError, ValidationError
-from odoo.tests.common import TransactionCase, users
+from odoo.tests.common import Form, TransactionCase, users
 
 from .cooperator_test_mixin import CooperatorTestMixin
 
@@ -1233,6 +1233,38 @@ class CooperatorCase(TransactionCase, CooperatorTestMixin):
         seq_number = self._get_last_register_sequence_value()
         self.assertEqual(register_entry.name, str(seq_number))
         self.assertEqual(register_entry.register_number_operation, seq_number)
+
+    @freeze_time("2023-06-21")
+    def test_transfer_operation_form(self):
+        """
+        Test that the subscription request created during a share transfer
+        operation is updated with the correct values.
+        """
+        cooperator = self.create_dummy_cooperator()
+        f = Form(self.env["operation.request"])
+        f.operation_type = "transfer"
+        f.receiver_not_member = True
+        with f.subscription_request.new() as sr:
+            sr.firstname = "first name 2"
+            sr.lastname = "last name 2"
+            sr.email = "email2@example.net"
+            subscription_request_vals = self.get_dummy_subscription_requests_vals()
+            sr.country_id = self.env["res.country"].browse(
+                subscription_request_vals["country_id"]
+            )
+            for field in ["address", "zip_code", "city", "lang", "iban"]:
+                setattr(sr, field, subscription_request_vals[field])
+        f.partner_id = cooperator
+        f.share_product_id = self.share_y
+        f.quantity = 1
+        operation_request = f.save()
+        self.assertEqual(operation_request.subscription_request.state, "transfer")
+        self.assertEqual(
+            operation_request.subscription_request.share_product_id, self.share_y
+        )
+        self.assertEqual(operation_request.subscription_request.ordered_parts, 1)
+        operation_request.submit_operation()
+        operation_request.approve_operation()
 
     @freeze_time("2023-06-21")
     def test_transfer_operation_existing_cooperator(self):

--- a/cooperator/views/menus.xml
+++ b/cooperator/views/menus.xml
@@ -38,7 +38,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
         sequence="30"
     />
     <menuitem
-        name="Operation request"
+        name="Operation Request"
         id="menu_cooperator_operation_request"
         action="operation_request_action"
         parent="menu_cooperator_main_subscription"


### PR DESCRIPTION
update share fields values of the internal subscription request of a transfer operation to a non-member when these values are changed in the form. this ensures that the values are correct even if the subscription request is created before the values are set.