### PR TITLE
[16.0][FIX] fix "blocked" state not renamed everywhere

### DIFF
--- a/cooperator/models/subscription_request.py
+++ b/cooperator/models/subscription_request.py
@@ -865,17 +865,17 @@ class SubscriptionRequest(models.Model):
         self.ensure_one()
         if self.state != "draft":
             raise ValidationError(_("Only draft requests can be blocked."))
-        self.write({"state": "block"})
+        self.write({"state": "blocked"})
 
     def unblock_subscription_request(self):
         self.ensure_one()
-        if self.state != "block":
+        if self.state != "blocked":
             raise ValidationError(_("Only blocked requests can be unblocked."))
         self.write({"state": "draft"})
 
     def cancel_subscription_request(self):
         self.ensure_one()
-        if self.state not in ("draft", "waiting", "done", "block"):
+        if self.state not in ("draft", "waiting", "done", "blocked"):
             raise ValidationError(_("You cannot cancel a request in this " "state."))
         self.write({"state": "cancelled"})
 

--- a/cooperator/readme/newsfragments/150.bugfix.rst
+++ b/cooperator/readme/newsfragments/150.bugfix.rst
@@ -1,0 +1,1 @@
+Rename obsolete occurrences of the ``blocked`` ``subscription.request`` state still present as ``block``.

--- a/cooperator/views/subscription_request_view.xml
+++ b/cooperator/views/subscription_request_view.xml
@@ -51,7 +51,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                     string="Unblock"
                     aria-label="Unblock"
                     name="unblock_subscription_request"
-                    states="block"
+                    states="blocked"
                     groups="cooperator.cooperator_group_user"
                 />
             </tree>
@@ -80,7 +80,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                         string="Cancel"
                         type="object"
                         name="cancel_subscription_request"
-                        states="draft,waiting,done,block"
+                        states="draft,waiting,done,blocked"
                         groups="cooperator.cooperator_group_user"
                     />
                     <field


### PR DESCRIPTION
rename obsolete occurrences of the `blocked` `subscription.request` state still present as `block`.

fixes #150.