### PR TITLE
[16.0][IMP] cooperator birthdate validation

### DIFF
--- a/cooperator/models/subscription_request.py
+++ b/cooperator/models/subscription_request.py
@@ -53,6 +53,21 @@ class SubscriptionRequest(models.Model):
             required_fields.append("generic_rules_approved")
         return required_fields
 
+    @api.constrains("birthdate")
+    def _check_birthdate(self):
+        for request in self:
+            if request.birthdate:
+                if request.birthdate > date.today():
+                    raise ValidationError(_("Date of birth cannot be in the future."))
+                min_date = date(1000, 1, 1)
+                if request.birthdate < min_date:
+                    raise ValidationError(
+                        _(
+                            "Please enter the full birth year with all digits "
+                            "(e.g., 1990, not 90)."
+                        )
+                    )
+
     @api.constrains("share_product_id", "is_company")
     def _check_share_available_to_user(self):
         for request in self:

--- a/cooperator/readme/newsfragments/176.feature.rst
+++ b/cooperator/readme/newsfragments/176.feature.rst
@@ -1,0 +1,1 @@
+Ensure that the birthdate field of subscription requests has at least 4 digits and is not in the future.

--- a/cooperator/tests/test_cooperator.py
+++ b/cooperator/tests/test_cooperator.py
@@ -1634,3 +1634,15 @@ class CooperatorCase(TransactionCase, CooperatorTestMixin):
         self.assertEqual(inactive_user.company_ids, self.env.company)
         self.assertEqual(inactive_user.company_id, self.env.company)
         self.assertTrue(inactive_user.active)
+
+    @users("user-cooperator")
+    def test_cooperator_birthdate_constraint(self):
+        """
+        Test that the birthdate is correctly validated on subscription request
+        """
+        self.subscription_request_1.validate_subscription_request()
+        with self.assertRaises(ValidationError):
+            self.subscription_request_1.birthdate = "0080-01-01"
+        date_tomorrow = date.today() + timedelta(days=1)
+        with self.assertRaises(ValidationError):
+            self.subscription_request_1.birthdate = date_tomorrow

--- a/cooperator_website/controllers/main.py
+++ b/cooperator_website/controllers/main.py
@@ -5,7 +5,7 @@
 
 import base64
 import re
-from datetime import datetime
+from datetime import date, datetime
 from urllib.parse import urljoin
 
 from odoo import http
@@ -325,6 +325,22 @@ class WebsiteSubscription(http.Controller):
 
         # There's no issue with the email, so we can remember the confirmation email
         values["confirm_email"] = email
+
+        # check the birthdate
+        birthdate = date.fromisoformat(kwargs["birthdate"])
+        if birthdate > date.today():
+            values["error_msg"] = _("Date of birth cannot be in the future.")
+        min_date = date(1000, 1, 1)
+        if birthdate < min_date:
+            values["error_msg"] = _(
+                "Please enter the full birth year with all digits "
+                "(e.g., 1990, not 90)."
+            )
+        if "error_msg" in values:
+            # error message is set: the birthdate is incorrect
+            values = self.fill_values(values, is_company, logged)
+            values["error"] = {"birthdate"}
+            return request.render(redirect, values)
 
         company = request.website.company_id
         if company.allow_id_card_upload:

--- a/cooperator_website/readme/newsfragments/176.feature.rst
+++ b/cooperator_website/readme/newsfragments/176.feature.rst
@@ -1,0 +1,1 @@
+Ensure that the date of birth entered on the subscription form has at least 4 digits and is not in the future.

--- a/cooperator_website/views/subscription_template.xml
+++ b/cooperator_website/views/subscription_template.xml
@@ -74,7 +74,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                         required="true"
                         t-att-readonly="logged"
                         t-att-value="birthdate"
-                        placeholder="1978-03-05"
+                        t-att-max="datetime.date.today().strftime('%Y-%m-%d')"
+                        min="1000-01-01"
                     />
                 </div>
             </div>


### PR DESCRIPTION
### Description

Restricts the birth date of cooperator subscription to be after 1900 and before today. Both on the client side, in the subscription form and in the backend by adding a constraint to the field.

[Internal task: 15540](https://gestion.coopiteasy.be/web#id=15540&action=479&model=project.task&view_type=form&menu_id=536)